### PR TITLE
ci(dependabot): schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,10 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+      day: 'saturday'
+      time: '10:00'
+      timezone: 'Asia/Tokyo'
     assignees:
       - 'jnicrimi'
     reviewers:
@@ -13,7 +16,10 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+      day: 'saturday'
+      time: '10:00'
+      timezone: 'Asia/Tokyo'
     assignees:
       - 'jnicrimi'
     reviewers:


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Chore: `.github/dependabot.yml`の更新。依存関係の更新スケジュールを毎日から毎週に変更し、npmとGitHub Actionsパッケージエコシステムの両方でスケジュール設定を詳細化（日、時間、タイムゾーン）。また、'jnicrimi'を割り当て人とレビュアーとして指定。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->