### PR TITLE
fix(vim): polyglot disabled, vue

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -89,6 +89,9 @@ if has('syntax')
   call ZenkakuSpace()
 endif
 
+" vim-polyglot
+let g:polyglot_disabled = ['vue']
+
 " vim-plug
 call plug#begin('~/.vim/plugged')
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- `vim-polyglot` における `vue` 構文サポートを無効化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->