### PR TITLE
fix(fish): confirm prompt

### DIFF
--- a/.config/fish/functions/fgdel.fish
+++ b/.config/fish/functions/fgdel.fish
@@ -9,8 +9,8 @@ function fgdel
   end
   set -l prompt "delete: $target_branch"
   echo "$prompt"
-  read -P "(yes/no) " -l confirm
-  if test "$confirm" != "yes"
+  read -P "[y/N] " -l confirm
+  if test "$confirm" != "y" -a "$confirm" != "Y"
     return 0
   end
   git branch -D "$target_branch"

--- a/.config/fish/functions/fgmerge.fish
+++ b/.config/fish/functions/fgmerge.fish
@@ -10,8 +10,8 @@ function fgmerge
   end
   set -l prompt "merge: $target_branch > $current_branch"
   echo "$prompt"
-  read -P "(yes/no) " -l confirm
-  if test "$confirm" != "yes"
+  read -P "[y/N] " -l confirm
+  if test "$confirm" != "y" -a "$confirm" != "Y"
     return 0
   end
   git merge "$target_branch"

--- a/.config/fish/functions/ggpush.fish
+++ b/.config/fish/functions/ggpush.fish
@@ -7,8 +7,8 @@ function ggpush
   set -l repository (git remote show)
   set -l prompt "push: $branch > origin/$branch"
   echo "$prompt"
-  read -P "(yes/no) " -l confirm
-  if test "$confirm" != "yes"
+  read -P "[y/N] " -l confirm
+  if test "$confirm" != "y" -a "$confirm" != "Y"
     return 0
   end
   git push "$repository" "$branch"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 削除・マージ・プッシュ時の確認プロンプトが「(yes/no)」から「[y/N]」に変更され、"y" または "Y" で簡単に操作を承認できるようになりました。その他の入力や未入力はキャンセル扱いとなります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->