### PR TITLE
refactor(fish): rename functions

### DIFF
--- a/.config/fish/functions/ggcd.fish
+++ b/.config/fish/functions/ggcd.fish
@@ -1,4 +1,4 @@
-function fcd
+function ggcd
 
   _assert_in_git_repository
   or return 1

--- a/.config/fish/functions/ggdel.fish
+++ b/.config/fish/functions/ggdel.fish
@@ -1,4 +1,4 @@
-function fgdel
+function ggdel
 
   _assert_in_git_repository
   or return 1

--- a/.config/fish/functions/ggdiff.fish
+++ b/.config/fish/functions/ggdiff.fish
@@ -1,9 +1,9 @@
-function fgdiff
+function ggdiff
 
   _assert_in_git_repository
   or return 1
 
-  argparse -n fgdiff 's/stat' -- $argv
+  argparse -n ggdiff 's/stat' -- $argv
   or return 1
 
   set -l selected_branch (_select_other_branch)

--- a/.config/fish/functions/ggmerge.fish
+++ b/.config/fish/functions/ggmerge.fish
@@ -1,4 +1,4 @@
-function fgmerge
+function ggmerge
 
   _assert_in_git_repository
   or return 1

--- a/.config/fish/functions/ggpr.fish
+++ b/.config/fish/functions/ggpr.fish
@@ -1,4 +1,4 @@
-function fgpr
+function ggpr
 
   _assert_in_git_repository
   or return 1

--- a/.config/fish/functions/ggrepo.fish
+++ b/.config/fish/functions/ggrepo.fish
@@ -1,4 +1,4 @@
-function fghq
+function ggrepo
 
   set -l repository (ghq list | fzf)
 

--- a/.config/fish/functions/ggshow.fish
+++ b/.config/fish/functions/ggshow.fish
@@ -1,9 +1,9 @@
-function fgshow
+function ggshow
 
   _assert_in_git_repository
   or return 1
 
-  argparse -n fgshow 'p/path=' -- $argv
+  argparse -n ggshow 'p/path=' -- $argv
   or return 1
 
   set -l commit_hash

--- a/.config/fish/functions/ggsw.fish
+++ b/.config/fish/functions/ggsw.fish
@@ -1,4 +1,4 @@
-function fgsw
+function ggsw
 
   _assert_in_git_repository
   or return 1

--- a/.config/fish/functions/ggwt.fish
+++ b/.config/fish/functions/ggwt.fish
@@ -1,4 +1,4 @@
-function fgwt
+function ggwt
 
   _assert_in_git_repository
   or return 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **リファクタ**
  * 複数のコマンド名が「fg」プレフィックスから「gg」プレフィックスに変更されました（例：fcd → ggcd、fgdel → ggdel など）。  
  * 機能や動作に変更はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->