### PR TITLE
refactor: improve setup.sh prompt to use y/N format

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -34,8 +34,8 @@ delete_symlink() {
   echo "unlink: $_dst_path"
 }
 
-read -rp "Setup dotfiles? (yes/no) " answer
-if [ "$answer" != "yes" ]; then
+read -rp "Setup dotfiles? (y/N) " answer
+if [ "$answer" != "y" ] && [ "$answer" != "Y" ]; then
   exit
 fi
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * dotfilesセットアップ時のユーザー確認プロンプトを「Setup dotfiles? (y/N)」に変更しました。

* **バグ修正**
  * 「y」または「Y」と入力した場合のみセットアップを続行し、それ以外の入力や未入力時はスクリプトを即終了するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->