### PR TITLE
fix: include merge commits in _select_commit function

### DIFF
--- a/.config/fish/functions/_select_commit.fish
+++ b/.config/fish/functions/_select_commit.fish
@@ -8,9 +8,9 @@ function _select_commit
   set -l commit_hash
 
   if test -n "$path_filter"
-    set commit_hash (git log --no-merges --pretty=format:"%H - %an : %s" -- "$path_filter" | fzf --prompt="Commit: " --preview 'git show --color=always {1}' | cut -d " " -f1)
+    set commit_hash (git log --pretty=format:"%H - %an : %s" -- "$path_filter" | fzf --prompt="Commit: " --preview 'git show --color=always {1}' | cut -d " " -f1)
   else
-    set commit_hash (git log --no-merges --pretty=format:"%H - %an : %s" | fzf --prompt="Commit: " --preview 'git show --color=always {1}' | cut -d " " -f1)
+    set commit_hash (git log --pretty=format:"%H - %an : %s" | fzf --prompt="Commit: " --preview 'git show --color=always {1}' | cut -d " " -f1)
   end
 
   if test -z "$commit_hash"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * コミット選択時にマージコミットも一覧に表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->