### PR TITLE
fix: add --color=never to git commands for proper fzf parsing

### DIFF
--- a/.config/fish/functions/_select_commit.fish
+++ b/.config/fish/functions/_select_commit.fish
@@ -8,9 +8,9 @@ function _select_commit
   set -l commit_hash
 
   if test -n "$path_filter"
-    set commit_hash (git log --pretty=format:"%H - %an : %s" -- "$path_filter" | fzf --prompt="Commit: " --preview 'git show --color=always {1}' | cut -d " " -f1)
+    set commit_hash (git log --color=never --pretty=format:"%H - %an : %s" -- "$path_filter" | fzf --prompt="Commit: " --preview 'git show --color=always {1}' | cut -d " " -f1)
   else
-    set commit_hash (git log --pretty=format:"%H - %an : %s" | fzf --prompt="Commit: " --preview 'git show --color=always {1}' | cut -d " " -f1)
+    set commit_hash (git log --color=never --pretty=format:"%H - %an : %s" | fzf --prompt="Commit: " --preview 'git show --color=always {1}' | cut -d " " -f1)
   end
 
   if test -z "$commit_hash"

--- a/.config/fish/functions/_select_other_branch.fish
+++ b/.config/fish/functions/_select_other_branch.fish
@@ -2,14 +2,14 @@ function _select_other_branch
 
   set -l current_branch (git branch --show-current)
   set -l escaped_branch (string escape --style=regex "$current_branch")
-  set -l branches (git branch --format="%(refname:short)" | string match -r -v "^$escaped_branch\$")
+  set -l branches (git branch --color=never --format="%(refname:short)" | string match -r -v "^$escaped_branch\$")
 
   if test -z "$branches"
     echo "No other branches found" >&2
     return 1
   end
 
-  set -l selected_branch (printf '%s\n' $branches | fzf --prompt="Branch: " --preview 'git log --oneline {}')
+  set -l selected_branch (printf '%s\n' $branches | fzf --prompt="Branch: " --preview 'git log --color=always --oneline {}')
 
   if test -z "$selected_branch"
     return 1

--- a/.config/fish/functions/ggrebase.fish
+++ b/.config/fish/functions/ggrebase.fish
@@ -3,7 +3,7 @@ function ggrebase --description "Interactive rebase"
   _assert_in_git_repository
   or return 1
 
-  set -l commit_hash (git log --oneline | fzf --prompt="Commit: " --preview 'git show --color=always {1}' --preview-window=right:60% | awk '{print $1}')
+  set -l commit_hash (git log --color=never --oneline | fzf --prompt="Commit: " --preview 'git show --color=always {1}' --preview-window=right:60% | awk '{print $1}')
 
   if test -z "$commit_hash"
     return 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * コミットやブランチのリスト表示で、カラーコードを無効化し、表示の一貫性を向上させました。
  * プレビュー表示ではカラー出力を維持し、選択時の視認性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->