### PR TITLE
perf: git logの表示件数を30件に制限

### DIFF
--- a/.config/fish/functions/_select_other_branch.fish
+++ b/.config/fish/functions/_select_other_branch.fish
@@ -9,7 +9,7 @@ function _select_other_branch
     return 1
   end
 
-  set -l selected_branch (printf '%s\n' $branches | fzf --prompt="Branch: " --preview 'git log --color=always --oneline {}')
+  set -l selected_branch (printf '%s\n' $branches | fzf --prompt="Branch: " --preview 'git log --color=always --oneline -n 30 {}')
 
   if test -z "$selected_branch"
     return 1

--- a/.config/fish/functions/ggrebase.fish
+++ b/.config/fish/functions/ggrebase.fish
@@ -3,7 +3,7 @@ function ggrebase --description "Interactive rebase"
   _assert_in_git_repository
   or return 1
 
-  set -l commit_hash (git log --color=never --oneline | fzf --prompt="Commit: " --preview 'git show --color=always {1}' --preview-window=right:60% | awk '{print $1}')
+  set -l commit_hash (git log --color=never --oneline -n 30 | fzf --prompt="Commit [recent 30]: " --preview 'git show --color=always {1}' --preview-window=right:60% | awk '{print $1}')
 
   if test -z "$commit_hash"
     return 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ブランチ選択時のプレビューとインタラクティブリベースのコミット一覧が、最新30件のコミットのみ表示されるようになりました。
  * リベース時のプロンプト表示が「Commit [recent 30]:」に変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->