### PR TITLE
fix: handle detached HEAD state in ggbr and ggdiff

### DIFF
--- a/.config/fish/functions/ggbr.fish
+++ b/.config/fish/functions/ggbr.fish
@@ -69,6 +69,11 @@ end
 function _ggbr_rename
   set -l current_branch (git branch --show-current)
 
+  if test -z "$current_branch"
+    echo "Error: Cannot rename branch in detached HEAD state" >&2
+    return 1
+  end
+
   read -P "Enter new branch name: " -c "$current_branch" new_branch
   or return 0
 

--- a/.config/fish/functions/ggdiff.fish
+++ b/.config/fish/functions/ggdiff.fish
@@ -7,6 +7,11 @@ function ggdiff --description "Show git differences"
   or return 0
   set -l current_branch (git branch --show-current)
 
+  if test -z "$current_branch"
+    echo "Error: Cannot show diff in detached HEAD state" >&2
+    return 1
+  end
+
   set -l action (_select_menu "Action" "diff" "stat")
   or return 0
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * Gitのdetached HEAD状態（現在のブランチが設定されていない場合）で、ブランチ名の変更や差分表示を試みた際に、適切なエラーメッセージを表示し、処理を中断するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->