### PR TITLE
chore: disable MD029 rule in markdownlint config

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -6,3 +6,5 @@ MD013: false
 
 MD024:
   siblings_only: true
+
+MD029: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Markdownリント設定でMD029ルールを無効化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->