### PR TITLE
refactor: rename ggrepo command to repo

### DIFF
--- a/.config/fish/functions/repo.fish
+++ b/.config/fish/functions/repo.fish
@@ -1,4 +1,4 @@
-function ggrepo --description "Navigate to repositories"
+function repo --description "Navigate to repositories using ghq"
 
   set -l repository (ghq list | fzf --prompt="Repository: ")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * コマンド名を `ggrepo` から `repo` に変更し、説明文を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->