### PR TITLE
docs: remove priority column from commit type table

### DIFF
--- a/.claude/commands/make-commit.md
+++ b/.claude/commands/make-commit.md
@@ -10,18 +10,18 @@
 
 **SHOULD**: 複数のtypeに該当する場合は、上位のtypeを優先して選択する
 
-| type | 説明 | 優先順 | 使用例 |
-|---|---|---|---|
-| feat | 新機能（新しい機能の追加） | 1 | `feat: add user authentication` |
-| fix | バグ修正（バグの修正） | 2 | `fix: resolve login error` |
-| refactor | リファクタリング（バグ修正でも機能追加でもないコード変更） | 3 | `refactor: improve auth logic` |
-| docs | ドキュメント（ドキュメントのみの変更） | 4 | `docs: update API guide` |
-| test | テスト（不足しているテストの追加や既存のテストの修正） | 5 | `test: add unit tests` |
-| style | スタイル（コードの意味に影響しない変更） | 6 | `style: format code` |
-| build | ビルド（ビルドシステムや外部依存関係に影響する変更） | 7 | `build: update webpack config` |
-| ci | CI（CI設定ファイルやスクリプトの変更） | 8 | `ci: add GitHub Actions` |
-| perf | パフォーマンス（パフォーマンスを向上させるコード変更） | 9 | `perf: optimize queries` |
-| chore | 雑務（srcやtestファイルを変更しないその他の変更） | 10 | `chore: update dependencies` |
+| type | 説明 | 使用例 |
+|---|---|---|
+| feat | 新機能（新しい機能の追加） | `feat: add user authentication` |
+| fix | バグ修正（バグの修正） | `fix: resolve login error` |
+| refactor | リファクタリング（バグ修正でも機能追加でもないコード変更） | `refactor: improve auth logic` |
+| docs | ドキュメント（ドキュメントのみの変更） | `docs: update API guide` |
+| test | テスト（不足しているテストの追加や既存のテストの修正） | `test: add unit tests` |
+| style | スタイル（コードの意味に影響しない変更） | `style: format code` |
+| build | ビルド（ビルドシステムや外部依存関係に影響する変更） | `build: update webpack config` |
+| ci | CI（CI設定ファイルやスクリプトの変更） | `ci: add GitHub Actions` |
+| perf | パフォーマンス（パフォーマンスを向上させるコード変更） | `perf: optimize queries` |
+| chore | 雑務（srcやtestファイルを変更しないその他の変更） | `chore: update dependencies` |
 
 ### メッセージ形式
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* ドキュメント
  * Conventional Commits のタイプ表から「優先順」列を削除し、3列（type／説明／使用例）に簡素化。各タイプの優先度数値とヘッダーを廃止。その他の記述は変更せず、内容の意味合いを維持。表の可読性と参照性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->