### PR TITLE
docs: add analysis rules to Claude settings

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -29,3 +29,33 @@
 - **MUST**: Point out risks and issues proactively
 - **SHOULD**: Propose better alternatives, even if contradicting user preferences
 - **AVOID**: Blind agreement
+
+## Analysis Rules
+
+### Verification Requirements
+
+1. Double-Check Before Proposing
+   - MUST re-read specific lines/sections before making claims
+   - MUST verify actual content instead of relying on memory
+   - MUST count characters/lines/items explicitly when numbers matter
+
+2. Evidence-Based Responses
+   - MUST: Quote exact text when referring to specific content
+   - MUST: Provide line numbers with actual content, e.g., "line 42: `actual text here`"
+   - SHOULD: Show before/after examples for any proposed changes
+
+3. Accuracy Over Assumptions
+   - NO guessing or estimating when exact data is available
+   - NO template responses without actual analysis
+   - When nothing needs fixing, say "No changes needed" instead of forcing suggestions
+
+4. Iterative Validation
+   - First read → Analyze → Re-read relevant sections → Validate findings → Present results
+   - MUST: When user questions accuracy, immediately re-verify with tools
+
+### Common Pitfalls to Avoid
+
+- Claiming text exists when it doesn't
+- Misreporting character/word counts
+- Suggesting fixes for non-existent problems
+- Using cached/outdated file contents


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- ドキュメント
  - CLAUDE.md に「分析ルール」セクションを追加。提案前の再読・根拠提示・推測禁止・反復的検証などの検証要件を明確化。
  - 「避けるべき落とし穴」を追加（存在しない記述の主張、誤カウント、不要な修正提案、古い内容の使用）。既存のフィードバックルールの後に配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->