### PR TITLE
fix: improve setup confirmation prompt with input validation loop

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -36,10 +36,20 @@ delete_symlink() {
   unlinked_files+=("$_dst_path")
 }
 
-read -rp "Setup dotfiles? (y/N) " answer
-if [ "$answer" != "y" ] && [ "$answer" != "Y" ]; then
-  exit
-fi
+while true; do
+  read -rp "Setup dotfiles? (y/N) " answer
+  case "$answer" in
+    y|Y)
+      break
+      ;;
+    N)
+      exit
+      ;;
+    *)
+      continue
+      ;;
+  esac
+done
 
 echo -n -e "\n"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - セットアップ時の確認を対話式に強化。表示「Setup dotfiles? (y/N)」に対し、y/Yで続行、Nで中止、それ以外は再入力を促します。
  - 誤操作の防止と入力の明確化により、初期設定体験を改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->