### PR TITLE
refactor: simplify setup prompt

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -37,12 +37,12 @@ delete_symlink() {
 }
 
 while true; do
-  read -rp "Setup dotfiles? (y/N) " answer
+  read -rp "[y/n] " answer
   case "$answer" in
     y|Y)
       break
       ;;
-    N)
+    n|N)
       exit
       ;;
     *)
@@ -131,12 +131,7 @@ for symlink in $broken_agent_links; do
   delete_symlink ".claude/agents/$file_name"
 done
 
-echo "========================================="
-echo "Setup Summary"
-echo "========================================="
-
 if [ ${#created_links[@]} -gt 0 ]; then
-  echo ""
   echo "Created symlinks (${#created_links[@]}):"
   for link in "${created_links[@]}"; do
     echo "  ✓ $link"
@@ -144,7 +139,6 @@ if [ ${#created_links[@]} -gt 0 ]; then
 fi
 
 if [ ${#unlinked_files[@]} -gt 0 ]; then
-  echo ""
   echo "Removed broken links (${#unlinked_files[@]}):"
   for link in "${unlinked_files[@]}"; do
     echo "  ✗ $link"
@@ -152,5 +146,5 @@ if [ ${#unlinked_files[@]} -gt 0 ]; then
 fi
 
 if [ ${#created_links[@]} -eq 0 ] && [ ${#unlinked_files[@]} -eq 0 ]; then
-  echo "  No changes made (all symlinks already exist)"
+  echo "No changes"
 fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 対話プロンプトを「[y/n]」に変更。n/Nで終了、y/Yで進行、既定は続行に統一。
- Style
  - 出力を簡素化（セットアップサマリーのバナーと区切り線を削除、各セクション前の空行を削除）。
  - 最終メッセージを「No changes made (all symlinks already exist)」から「No changes」に短縮。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->