### PR TITLE
chore: remove vim-fish plugin

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -97,7 +97,6 @@ call plug#begin('~/.vim/plugged')
 
 Plug 'Yggdroot/indentLine'
 Plug 'airblade/vim-gitgutter'
-Plug 'dag/vim-fish'
 Plug 'dense-analysis/ale'
 Plug 'editorconfig/editorconfig-vim'
 Plug 'junegunn/fzf', { 'dir': '~/.fzf', 'do': './install --all' }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fishシェル向けシンタックス関連プラグインを削除しました。これにより、Fishファイルでのシンタックスハイライト等は読み込まれなくなります。
  * 不要プラグインの削減により、起動の軽量化が見込まれます。他のプラグイン構成に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->