### PR TITLE
feat: add gruvbox colorscheme

### DIFF
--- a/.config/nvim/lua/config/lazy.lua
+++ b/.config/nvim/lua/config/lazy.lua
@@ -21,6 +21,6 @@ require("lazy").setup({
   spec = {
     { import = "plugins" },
   },
-  install = { colorscheme = { "habamax" } },
+  install = { colorscheme = { "gruvbox" } },
   checker = { enabled = true },
 })

--- a/.config/nvim/lua/plugins/gruvbox.lua
+++ b/.config/nvim/lua/plugins/gruvbox.lua
@@ -1,0 +1,11 @@
+return {
+  "ellisonleao/gruvbox.nvim",
+  priority = 1000,
+  config = function()
+    require("gruvbox").setup({
+      contrast = "medium", -- hard, medium, soft
+      transparent_mode = false,
+    })
+    vim.cmd("colorscheme gruvbox")
+  end,
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - Gruvbox テーマを追加し、起動時に自動適用。コントラストは「medium」、透過は無効を既定化。配色の一貫性と可読性が向上。
- スタイル
  - 既定のカラースキームを Habamax から Gruvbox に切り替え。エディタ全体の配色を刷新し、ダーク背景での視認性を改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->