### PR TITLE
feat: add which-key plugin

### DIFF
--- a/.config/nvim/lua/plugins/which-key.lua
+++ b/.config/nvim/lua/plugins/which-key.lua
@@ -1,0 +1,24 @@
+return {
+  "folke/which-key.nvim",
+  event = "VeryLazy",
+  opts = {},
+  config = function()
+    local wk = require("which-key")
+    wk.setup({})
+
+    -- キーマップのグループ設定
+    wk.add({
+      { "<leader>f", group = "file" },
+      { "<leader>g", group = "git" },
+    })
+  end,
+  keys = {
+    {
+      "<leader>?",
+      function()
+        require("which-key").show({ global = false })
+      end,
+      desc = "Buffer Local Keymaps (which-key)",
+    },
+  },
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - which-key を導入し、イベントトリガーで遅延読み込みを実装。
  - which-key の初期化と基本設定を追加。
  - <leader>? でバッファローカルのキーマップ一覧を表示（説明ラベル付き）。
  - <leader>f を「file」、<leader>g を「git」のキーグループとして登録。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->