### PR TITLE
chore: remove comments from nvim configs

### DIFF
--- a/.config/nvim/lua/core/keymaps.lua
+++ b/.config/nvim/lua/core/keymaps.lua
@@ -1,8 +1,6 @@
 local keymap = vim.keymap
 
--- 折り返し行での移動
 keymap.set('n', '<Down>', 'gj')
 keymap.set('n', '<Up>', 'gk')
 
--- 検索ハイライト解除
 keymap.set('n', '<Esc><Esc>', ':nohlsearch<CR>', { silent = true })

--- a/.config/nvim/lua/plugins/fzf-lua.lua
+++ b/.config/nvim/lua/plugins/fzf-lua.lua
@@ -3,8 +3,6 @@ return {
   dependencies = { "nvim-tree/nvim-web-devicons" },
   config = function()
     require("fzf-lua").setup({})
-
-    -- キーマップ設定
     local map = vim.keymap.set
     map("n", "<leader>ff", "<cmd>FzfLua files<cr>", { desc = "Find files" })
     map("n", "<leader>gf", "<cmd>FzfLua git_files<cr>", { desc = "Git files" })

--- a/.config/nvim/lua/plugins/indent-blankline.lua
+++ b/.config/nvim/lua/plugins/indent-blankline.lua
@@ -1,7 +1,5 @@
 return {
   "lukas-reineke/indent-blankline.nvim",
   main = "ibl",
-  ---@module "ibl"
-  ---@type ibl.config
   opts = {},
 }

--- a/.config/nvim/lua/plugins/vim-illuminate.lua
+++ b/.config/nvim/lua/plugins/vim-illuminate.lua
@@ -2,15 +2,11 @@ return {
   "RRethy/vim-illuminate",
   event = { "BufReadPost", "BufNewFile" },
   opts = {
-    -- 遅延時間の設定（ミリ秒）
     delay = 100,
-    -- 大きなファイルでの制限
     large_file_cutoff = 2000,
-    -- 大きなファイルでの上書き設定
     large_file_overrides = {
       providers = { "lsp" },
     },
-    -- 最小マッチ長
     min_count_to_highlight = 2,
   },
   config = function(_, opts)

--- a/.config/nvim/lua/plugins/which-key.lua
+++ b/.config/nvim/lua/plugins/which-key.lua
@@ -5,8 +5,6 @@ return {
   config = function()
     local wk = require("which-key")
     wk.setup({})
-
-    -- キーマップのグループ設定
     wk.add({
       { "<leader>f", group = "file" },
       { "<leader>g", group = "git" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- スタイル
  - 余分な空行・インラインコメント・不要な注釈を整理し、設定の可読性を向上。キーマップや各種プラグイン設定の値は不変です。
- ドキュメント
  - LuaDoc系の型注釈を削除（開発支援向け記述のみ変更）。
- チョア
  - 非機能変更のみのクリーンアップ。ユーザー向けの挙動・表示・パフォーマンスへの影響はありません。各種キーマップ、検索、ハイライト、インデント表示などの動作は一切変更なし。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->