### PR TITLE
chore: add obsidian and remove quiver from brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -62,6 +62,7 @@ cask "linear-linear"
 cask "logi-options+"
 cask "nordvpn"
 cask "notion"
+cask "obsidian"
 cask "postman"
 cask "raycast"
 cask "slack"
@@ -70,6 +71,5 @@ cask "zoom"
 mas "EdgeView", id: 1580323719
 mas "Kindle", id: 302584613
 mas "Messenger", id: 1480068668
-mas "Quiver", id: 866773894
 mas "Things", id: 904280696
 mas "Xcode", id: 497799835


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - セットアップ時にHomebrew Cask経由でObsidianの自動インストールを追加。初回環境構築がよりスムーズになります。
- 雑務
  - Mac App Store版Quiverのインストール対象を削除。既存環境には影響ありませんが、新規セットアップではインストールされません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->