### PR TITLE
chore: enable trailing whitespace removal for yaml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,6 @@ indent_size = 2
 
 [*.{yml,yaml}]
 indent_size = 2
-trim_trailing_whitespace = false
 
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- スタイル
  - YAMLファイルでも末尾の空白を自動削除するよう統一しました。フォーマットの一貫性が向上し、不要な差分が減少します。ユーザー向け機能や表示への影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->