### PR TITLE
chore: remove unused keymaps

### DIFF
--- a/.config/nvim/lua/plugins/fzf-lua.lua
+++ b/.config/nvim/lua/plugins/fzf-lua.lua
@@ -4,7 +4,6 @@ return {
   config = function()
     require("fzf-lua").setup({})
     local map = vim.keymap.set
-    map("n", "<leader>ff", "<cmd>FzfLua files<cr>", { desc = "Find files" })
     map("n", "<leader>gf", "<cmd>FzfLua git_files<cr>", { desc = "Git files" })
     map("n", "<leader>gs", "<cmd>FzfLua git_status<cr>", { desc = "Git status" })
   end,

--- a/.config/nvim/lua/plugins/which-key.lua
+++ b/.config/nvim/lua/plugins/which-key.lua
@@ -7,7 +7,6 @@ return {
     wk.setup({})
     wk.add({
       { "<leader>b", group = "buffer" },
-      { "<leader>f", group = "file" },
       { "<leader>g", group = "git" },
     })
   end,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- キーバインド
  - <leader>ff によるファイル検索ショートカットを削除しました（fzf-lua）。
  - which-key の「<leader>f → file」グループ表示を削除しました。
  - これにより、which-key のヒントおよび実行可能なショートカットからファイル検索エントリが消えます。既存の「<leader>b → buffer」「<leader>g → git」は変更ありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->