### PR TITLE
feat: add github copilot plugin for neovim

### DIFF
--- a/.config/nvim/lua/plugins/copilot.lua
+++ b/.config/nvim/lua/plugins/copilot.lua
@@ -1,0 +1,18 @@
+return {
+  "zbirenbaum/copilot.lua",
+  cmd = "Copilot",
+  event = "InsertEnter",
+  config = function()
+    require("copilot").setup({
+      suggestion = {
+        enabled = true,
+        auto_trigger = true,
+        keymap = {
+          accept = "<C-j>",
+          next = "<M-]>",
+          prev = "<M-[>",
+        },
+      },
+    })
+  end,
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - GitHub Copilot を Neovim に統合。挿入モードで自動起動。
  - 提案を自動トリガーし、インライン候補を表示。
  - 主要ショートカット: 受け入れ Ctrl-J、次候補 Alt-]、前候補 Alt-[。
  - 必要に応じてコマンドから起動可能。
  - 既定の設定で動作し、インストール後すぐに利用開始。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->