### PR TITLE
fix: resolve fzf preview paths in ggadd

### DIFF
--- a/.config/fish/functions/ggadd.fish
+++ b/.config/fish/functions/ggadd.fish
@@ -3,6 +3,8 @@ function ggadd --description "Add unstaged files interactively with fzf"
   _assert_in_git_repository
   or return 1
 
+  set -l git_root (git rev-parse --show-toplevel)
+
   set -l unstaged_files (git status --porcelain -z | \
       string split0 | \
       grep -E "^.[ACDMRT]|^\?\?" | \
@@ -16,9 +18,9 @@ function ggadd --description "Add unstaged files interactively with fzf"
   set -l selected_files (printf '%s\n' $unstaged_files | \
     fzf --multi \
         --prompt="Select files: " \
-        --preview 'git diff --color=always {} 2>/dev/null || \
-                   bat --color=always {} 2>/dev/null || \
-                   cat {}')
+        --preview "git -C $git_root diff --color=always {} 2>/dev/null || \
+                   bat --color=always $git_root/{} 2>/dev/null || \
+                   cat $git_root/{}")
 
   if test (count $selected_files) -eq 0
     return 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - なし
- バグ修正
  - プレビューがサブディレクトリからでも正しく表示されるよう改善。
  - 差分やファイル内容の参照をリポジトリルート基準の絶対パスに統一し、パス解決失敗や色付け欠落の不具合を解消。
- リファクタリング
  - プレビュー用のパス処理を一元化し、動作の一貫性と安定性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->