### PR TITLE
chore: add nvim scrolloff settings

### DIFF
--- a/.config/nvim/lua/core/options.lua
+++ b/.config/nvim/lua/core/options.lua
@@ -15,7 +15,9 @@ opt.listchars = {
   precedes = "«"
 }
 opt.number = true
+opt.scrolloff = 8
 opt.shiftwidth = 2
+opt.sidescrolloff = 8
 opt.shortmess:append "Ic"
 opt.showbreak = "↪"
 opt.showmatch = true

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,3 @@
+globals = {
+  "vim"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - カーソル周辺に常に上下8行・左右8列の余白を確保する設定を追加。スクロール時の視認性と快適さが向上。

- チョア
  - Lua リンター設定を追加し、vim をグローバルとして認識。開発時の警告を低減。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->