### PR TITLE
chore: add trouble buffer diagnostics

### DIFF
--- a/.config/nvim/lua/plugins/trouble.lua
+++ b/.config/nvim/lua/plugins/trouble.lua
@@ -4,5 +4,6 @@ return {
   cmd = "Trouble",
   keys = {
     { "<leader>xx", "<cmd>Trouble diagnostics toggle<cr>", desc = "Diagnostics" },
+    { "<leader>xX", "<cmd>Trouble diagnostics toggle filter.buf=0<cr>", desc = "Buffer Diagnostics" },
   },
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - Trouble で現在バッファの診断のみを素早く確認できる新しいショートカットを追加（<leader>xX）。現在のファイルに絞った問題の把握が容易になります。
  - 既存のグローバル診断ショートカット（<leader>xx）は従来通り利用可能で、使い分けが可能です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->