### PR TITLE
chore: add diff options to ggdiff

### DIFF
--- a/.config/fish/functions/ggdiff.fish
+++ b/.config/fish/functions/ggdiff.fish
@@ -15,11 +15,24 @@ function ggdiff --description "Show git differences"
   set -l action (_select_menu "Action" "diff" "stat")
   or return 0
 
+  set -l diff_options (_select_menu "Options" "空白・空行無視" "指定なし")
+  or return 0
+
   switch "$action"
     case "diff"
-      git diff "$selected_branch..$current_branch"
+      switch "$diff_options"
+        case "空白・空行無視"
+          git diff --ignore-all-space --ignore-blank-lines "$selected_branch..$current_branch"
+        case "指定なし"
+          git diff "$selected_branch..$current_branch"
+      end
     case "stat"
-      git diff --stat "$selected_branch..$current_branch"
+      switch "$diff_options"
+        case "空白・空行無視"
+          git diff --stat --ignore-all-space --ignore-blank-lines "$selected_branch..$current_branch"
+        case "指定なし"
+          git diff --stat "$selected_branch..$current_branch"
+      end
     case '*'
       return 0
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - ggdiffに空白・空行を無視する比較オプションを追加。選択メニューから「空白・空行無視」/「指定なし」を切替可能。
  - 選択内容は差分(diff)と統計(stat)の両方に適用され、不要な書式変更に左右されない比較が可能に。既存の挙動とエラーハンドリングは維持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->