### PR TITLE
feat: add edit mode to ggdiff

### DIFF
--- a/.config/fish/functions/ggdiff.fish
+++ b/.config/fish/functions/ggdiff.fish
@@ -12,11 +12,13 @@ function ggdiff --description "Show git differences"
     return 1
   end
 
-  set -l action (_select_menu "Action" "diff" "stat")
+  set -l action (_select_menu "Action" "diff" "stat" "edit")
   or return 0
 
-  set -l diff_options (_select_menu "Options" "空白・空行無視" "指定なし")
-  or return 0
+  if test "$action" != "edit"
+    set -l diff_options (_select_menu "Options" "空白・空行無視" "指定なし")
+    or return 0
+  end
 
   switch "$action"
     case "diff"
@@ -32,6 +34,15 @@ function ggdiff --description "Show git differences"
           git diff --stat --ignore-all-space --ignore-blank-lines "$selected_branch..$current_branch"
         case "指定なし"
           git diff --stat "$selected_branch..$current_branch"
+      end
+    case "edit"
+      set -l files (git diff --name-only "$selected_branch..$current_branch" | \
+        fzf --multi \
+            --prompt="Select files: " \
+            --preview="git diff '$selected_branch..$current_branch' -- {}")
+
+      if test -n "$files"
+        vim $files
       end
     case '*'
       return 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新機能
  * アクションメニューに「edit」を追加し、変更ファイルを選択してエディタで開けるようになりました。
  * 「edit」選択時は、変更ファイルの一覧を表示し、複数選択やファイルごとの差分プレビューに対応します。
  * 既存の「diff」「stat」は従来どおり利用可能で、「edit」選択時のみ不要な差分オプションの確認をスキップします。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->