### PR TITLE
chore: simplify ggrestore prompt text

### DIFF
--- a/.config/fish/functions/ggrestore.fish
+++ b/.config/fish/functions/ggrestore.fish
@@ -19,7 +19,7 @@ function ggrestore --description "Restore file changes interactively with fzf"
 
   set -l selected_files (printf '%s\n' $changed_files | \
     fzf --multi \
-        --prompt="Select files to restore: " \
+        --prompt="Select files: " \
         --preview "git -C $git_root diff HEAD --color=always {} 2>/dev/null || \
                    bat --color=always $git_root/{} 2>/dev/null || \
                    cat $git_root/{}")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- スタイル
  - 復元用のファイル選択プロンプトの文言を「Select files to restore: 」から「Select files: 」へ短縮し、視認性を改善。
  - 機能や挙動（選択・プレビュー・復元処理）に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->