### PR TITLE
refactor: reorganize fzf keymaps

### DIFF
--- a/.config/nvim/lua/core/keymaps.lua
+++ b/.config/nvim/lua/core/keymaps.lua
@@ -8,7 +8,6 @@ keymap.set('n', '<Up>', 'gk')
 keymap.set('n', '<Esc><Esc>', ':nohlsearch<CR>', { silent = true })
 
 -- Buffer operations
-keymap.set('n', '<leader>bb', '<Cmd>BufferLinePick<CR>', { desc = 'Pick buffer' })
 keymap.set('n', '<leader>bd', ':bd<CR>', { desc = 'Delete buffer' })
 keymap.set('n', '<leader>bn', ':bnext<CR>', { desc = 'Next buffer' })
 keymap.set('n', '<leader>bp', ':bprevious<CR>', { desc = 'Previous buffer' })

--- a/.config/nvim/lua/plugins/bufferline.lua
+++ b/.config/nvim/lua/plugins/bufferline.lua
@@ -3,12 +3,6 @@ return {
   version = "*",
   dependencies = { "nvim-tree/nvim-web-devicons" },
   config = function()
-    require("bufferline").setup({
-      options = {
-        pick = {
-          alphabet = "abcdefghijklmnopqrstuvwxyz"
-        }
-      }
-    })
+    require("bufferline").setup({})
   end,
 }

--- a/.config/nvim/lua/plugins/fzf-lua.lua
+++ b/.config/nvim/lua/plugins/fzf-lua.lua
@@ -4,7 +4,9 @@ return {
   config = function()
     require("fzf-lua").setup({})
     local map = vim.keymap.set
-    map("n", "<leader>gf", "<cmd>FzfLua git_files<cr>", { desc = "Git files" })
-    map("n", "<leader>gs", "<cmd>FzfLua git_status<cr>", { desc = "Git status" })
+    map("n", "<leader>fb", "<cmd>FzfLua buffers<cr>", { desc = "Find buffers" })
+    map("n", "<leader>ff", "<cmd>FzfLua git_files<cr>", { desc = "Find files" })
+    map("n", "<leader>fr", "<cmd>FzfLua oldfiles<cr>", { desc = "Find recent" })
+    map("n", "<leader>fs", "<cmd>FzfLua git_status<cr>", { desc = "Find status" })
   end,
 }

--- a/.config/nvim/lua/plugins/which-key.lua
+++ b/.config/nvim/lua/plugins/which-key.lua
@@ -7,6 +7,7 @@ return {
     wk.setup({})
     wk.add({
       { "<leader>b", group = "buffer" },
+      { "<leader>f", group = "find" },
       { "<leader>g", group = "git" },
       { "<leader>x", group = "trouble/diagnostics" },
     })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - <leader>f 配下に検索ショートカットを追加（fb: バッファ、ff: ファイル、fr: 最近使ったファイル、fs: Git ステータス）。
  - which-key に「find」グループを追加し、検索系キーマップの発見性を向上。

- 変更
  - Bufferline のバッファピック用カスタムアルファベットと <leader>bb キーマップを削除し、デフォルト動作へ移行。
  - 既存の gf（Git ファイル）/ gs（Git ステータス）キーマップを廃止し、<leader>f 系に統合。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->