### PR TITLE
chore: disable yamllint document-start

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -3,5 +3,6 @@
 extends: default
 
 rules:
+  document-start: disable
   line-length: disable
   truthy: disable


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **チョア**
  * yamllintのルールを更新し、document-startチェックを無効化しました。
  * 既存のline-lengthおよびtruthyの無効化設定と整合し、YAMLヘッダー（---）の有無でLintが失敗しないようにしました。
  * 開発フローとCIの安定性向上を目的とした設定見直しで、アプリの機能や表示への影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->