### PR TITLE
refactor: improve nvim keymaps

### DIFF
--- a/.config/nvim/lua/core/keymaps.lua
+++ b/.config/nvim/lua/core/keymaps.lua
@@ -7,7 +7,12 @@ keymap.set('n', '<Up>', 'gk')
 -- Search
 keymap.set('n', '<Esc><Esc>', ':nohlsearch<CR>', { silent = true })
 
+-- Line movement
+keymap.set('v', 'J', ":m '>+1<CR>gv=gv", { desc = 'Move line down' })
+keymap.set('v', 'K', ":m '<-2<CR>gv=gv", { desc = 'Move line up' })
+
 -- Buffer operations
+keymap.set('n', '<Tab>', '<cmd>bnext<CR>', { desc = 'Next buffer' })
+keymap.set('n', '<S-Tab>', '<cmd>bprevious<CR>', { desc = 'Previous buffer' })
+keymap.set('n', '<leader><Tab>', '<cmd>b#<CR>', { desc = 'Last buffer' })
 keymap.set('n', '<leader>bd', ':bd<CR>', { desc = 'Delete buffer' })
-keymap.set('n', '<leader>bn', ':bnext<CR>', { desc = 'Next buffer' })
-keymap.set('n', '<leader>bp', ':bprevious<CR>', { desc = 'Previous buffer' })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - ビジュアルモードでJ/Kにより選択行を上下移動。再選択と整形も自動実行。
  - 通常モードでTabで次バッファ、Shift-Tabで前バッファ、leader+Tabで直前バッファへ切替。
  - 新規マッピングに説明文を付与し、ヘルプ表示を改善。
- リファクタ
  - 旧バッファ移動のリーダーキー割り当て（leader+bn / leader+bp）を廃止し、操作体系を整理。
  - 既存のバッファ削除（leader+bd）などはそのまま維持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->