### PR TITLE
chore: add local bin to PATH

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -6,6 +6,7 @@ set -gx XDG_CONFIG_HOME $HOME/.config
 
 set -g fish_greeting ""
 
+fish_add_path $HOME/.local/bin
 fish_add_path $VOLTA_HOME/bin
 fish_add_path /opt/homebrew/bin
 fish_add_path /opt/homebrew/sbin


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - シェル起動時に $HOME/.local/bin を PATH に自動追加。ローカルに配置した実行ファイルをすぐに利用できます。
- Chores
  - 既存の PATH 追加（$VOLTA_HOME/bin、/opt/homebrew/bin、/opt/homebrew/sbin）は維持。起動フローやエラーハンドリングへの影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->