### PR TITLE
chore: update git editor to nvim

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -1,6 +1,6 @@
 [core]
   quotepath = false
-  editor = vim
+  editor = nvim
   pager = delta
 
 [fetch]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitのデフォルトエディタをvimからNeovim（nvim）に更新。コミットメッセージ編集やrebase等で起動するエディタがnvimになります。機能面の変更や他動作への影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->