### PR TITLE
chore: remove zoom from Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -72,7 +72,6 @@ cask "orbstack"
 cask "raycast"
 cask "slack"
 cask "tableplus"
-cask "zoom"
 mas "EdgeView", id: 1580323719
 mas "Kindle", id: 302584613
 mas "Messenger", id: 1480068668


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - Brewfile から Zoom の cask を削除しました。
  - これにより、この Brewfile を用いたセットアップや更新で Zoom はインストールされません。
  - 他の cask / mas エントリには変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->