### PR TITLE
chore: remove volta from fish config

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -1,13 +1,11 @@
 set -gx EDITOR nvim
 set -gx FZF_DEFAULT_OPTS "--height 100% --reverse --border=rounded --no-sort --exit-0 --ansi --info=inline --preview-window=right:50%:wrap --bind 'ctrl-/:preview-page-down,ctrl-\:preview-page-up'"
 set -gx LANG ja_JP.UTF-8
-set -gx VOLTA_HOME $HOME/.volta
 set -gx XDG_CONFIG_HOME $HOME/.config
 
 set -g fish_greeting ""
 
 fish_add_path $HOME/.local/bin
-fish_add_path $VOLTA_HOME/bin
 fish_add_path /opt/homebrew/bin
 fish_add_path /opt/homebrew/sbin
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア(Chores)
  - fish のシェル設定から VOLTA_HOME と $VOLTA_HOME/bin の PATH 追加を削除。これにより Volta 経由の Node/ツールは自動でパス解決されません。必要な場合は各自で PATH を再設定してください。
  - そのほかの環境変数、エイリアス、abbr、挨拶メッセージ等の設定は変更ありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->