### PR TITLE
chore: remove history abbreviations

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -40,8 +40,6 @@ abbr --add gl "git log --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %
 abbr --add glg "git log --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --graph"
 abbr --add gs 'git status --short --branch'
 abbr --add gwt 'git worktree'
-abbr --add h 'history'
-abbr --add hc 'history clear'
 abbr --add p 'pwd'
 abbr --add u 'cd ..'
 abbr --add x 'exit'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fish シェルの略語「h」（history）と「hc」（history clear）を削除しました。これらのショートカットは使用できなくなり、履歴の参照やクリアは各コマンドを直接入力してください。その他の略語定義に変更はありません。必要に応じて、各自のローカル設定で再定義できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->