### PR TITLE
chore: remove unnecessary document separators from yaml files

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,3 @@
----
-
 language: "ja"
 early_access: false
 reviews:

--- a/.config/gh/config.yml
+++ b/.config/gh/config.yml
@@ -1,5 +1,3 @@
----
-
 git_protocol: https
 editor:
 prompt: enabled

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,3 @@
----
-
 version: 2
 updates:
   - package-ecosystem: 'github-actions'

--- a/.github/workflows/preset-pr.yml
+++ b/.github/workflows/preset-pr.yml
@@ -1,5 +1,3 @@
----
-
 name: preset-pr
 on:
   pull_request:

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,5 +1,3 @@
----
-
 default: true
 
 MD013: false

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,3 @@
----
-
 extends: default
 
 rules:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,3 @@
----
-
 commit-msg:
   commands:
     commitlint:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - 複数の設定YAMLから不要な先頭行を削除し体裁を整理
  - PRワークフローのトリガーを「opened」「reopened」のみに限定
  - yamllintにルールを追加（document-start/line-length/truthy を無効化）
  - markdownlintの設定を微調整（機能変更なし）
  - dependabot等の設定を体裁修正（機能変更なし）
  - lefthookでcommitlintチェックを無効化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->