### PR TITLE
fix: restrict workflow permissions

### DIFF
--- a/.github/workflows/preset-pr.yml
+++ b/.github/workflows/preset-pr.yml
@@ -6,7 +6,9 @@ run-name: ${{ github.workflow }} (${{ github.ref_name }})
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
-permissions: write-all
+permissions:
+  pull-requests: write
+  issues: write
 jobs:
   call-preset-pr:
     uses: jnicrimi/reusable-workflows/.github/workflows/called-preset-pr.yml@main


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * セキュリティ強化のため、ワークフロー権限を「全体write」から「Pull Requests/Issuesへの書き込みのみ」に限定する細分化設定へ変更。既存のトリガー、同時実行制御、再利用ワークフロー呼び出しは維持。ユーザー向け機能への影響はなく、CIの動作は従来通りです。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->