### PR TITLE
chore: simplify editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,33 +4,10 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_style = space
-indent_size = unset
+indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.fish]
-indent_size = 2
-
-[*.js]
-indent_size = 2
-
-[*.json]
-indent_size = 2
-
-[*.kdl]
-indent_size = 2
-
-[*.lua]
-indent_size = 2
-
 [*.md]
+indent_size = unset
 trim_trailing_whitespace = false
-
-[*.sh]
-indent_size = 2
-
-[*.toml]
-indent_size = 2
-
-[*.{yml,yaml}]
-indent_size = 2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * プロジェクト全体のインデントを2スペースに統一し、言語別の上書きを廃止。
  * Markdownは行末の空白を保持し、インデントサイズの既定を未設定に変更。
* **Chores**
  * エディタ設定を整備し、チーム間のフォーマット差異を低減。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->