### PR TITLE
chore: remove run-name from preset-pr workflow

### DIFF
--- a/.github/workflows/preset-pr.yml
+++ b/.github/workflows/preset-pr.yml
@@ -2,7 +2,6 @@ name: preset-pr
 on:
   pull_request:
     types: [opened, reopened]
-run-name: ${{ github.workflow }} (${{ github.ref_name }})
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CIワークフロー設定を更新し、実行名の明示指定を削除しました。
  * 既存の権限・並列制御・プルリクエストのトリガー・ジョブ構成は維持されています。
  * 機能や画面表示への影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->