### PR TITLE
chore: remove ctrl-h unbind

### DIFF
--- a/.config/zellij/config.kdl
+++ b/.config/zellij/config.kdl
@@ -1,5 +1,4 @@
 keybinds clear-defaults=true {
-  unbind "Ctrl h"
   locked {
     bind "Ctrl g" { SwitchToMode "normal"; }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - なし
- バグ修正
  - Ctrl+H のグローバル無効化を撤廃し、移動モードでの既存動作を維持。期待どおりに反応しない場面を解消し、キー操作の一貫性と使い勝手を改善。
  - 他のキー設定への影響はなく、予期せぬショートカットの衝突を防止。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->