### PR TITLE
chore: add karabiner ime shortcuts

### DIFF
--- a/.config/karabiner/karabiner.json
+++ b/.config/karabiner/karabiner.json
@@ -5,8 +5,36 @@
             "complex_modifications": {
                 "rules": [
                     {
-                        "description": "Control+P/S/T を押したら IME を OFF にしてから送信",
+                        "description": "Control+H/N/P/S/T を押したら IME を OFF にしてから送信",
                         "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "h",
+                                    "modifiers": { "mandatory": ["control"] }
+                                },
+                                "to": [
+                                    { "key_code": "japanese_eisuu" },
+                                    {
+                                        "key_code": "h",
+                                        "modifiers": ["control"]
+                                    }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "key_code": "n",
+                                    "modifiers": { "mandatory": ["control"] }
+                                },
+                                "to": [
+                                    { "key_code": "japanese_eisuu" },
+                                    {
+                                        "key_code": "n",
+                                        "modifiers": ["control"]
+                                    }
+                                ],
+                                "type": "basic"
+                            },
                             {
                                 "from": {
                                     "key_code": "p",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - Ctrl+H/Ctrl+N で、まず IME をオフにしてから元のショートカットを送出する動作を追加。
  - 既存の Ctrl+P/S/T と同様の挙動を拡張し、入力中でもショートカットが安定して発動。
  - 日本語入力中の誤作動を軽減し、編集操作の一貫性を向上。
  - 切り替えの体感遅延はなく、日常の操作フローを妨げません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->