### PR TITLE
fix: use absolute paths in ggdiff edit mode

### DIFF
--- a/.config/fish/functions/ggdiff.fish
+++ b/.config/fish/functions/ggdiff.fish
@@ -37,13 +37,14 @@ function ggdiff --description "Show git differences"
           _set_commandline "git diff --stat $selected_branch..$current_branch"
       end
     case "edit"
+      set -l root (git rev-parse --show-toplevel)
       set -l files (git diff --name-only "$selected_branch..$current_branch" | \
         fzf --multi --prompt="Select files: ")
 
       if test -n "$files"
         set -l escaped_files
         for file in $files
-          set -a escaped_files (string escape -- $file)
+          set -a escaped_files (string escape -- "$root/$file")
         end
         _set_commandline "vim $escaped_files"
       end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- バグ修正
  - 編集アクションで選択ファイルをエディタに渡す際、リポジトリルート基準のパス解決に変更。サブディレクトリから実行しても正しく開け、ファイル名にスペースや特殊文字が含まれていても失敗しにくくなりました。従来の「ファイルが見つからない」やパス解釈の不具合を解消。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->