### PR TITLE
style: add fish script indent configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,9 @@ indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.fish]
+indent_size = 4
+
 [*.md]
 indent_size = unset
 trim_trailing_whitespace = false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* チョア
  * エディタ設定を更新し、.fish ファイルのインデント幅を4に設定。
  * Markdown は現状維持（indent_size 未設定、末尾空白トリム無効）、既存の一般設定にも変更なし。
  * 対象は .fish 拡張子のファイルに限定。既存のファイル形式に対する規則は保持。
  * プロジェクトの動作やビルドへの影響はなし。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->