### PR TITLE
chore: remove duplicate AGENTS.md symlink

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -130,7 +130,6 @@ for config_file in "${config_files[@]}"; do
   create_symlink "$config_file"
 done
 
-create_symlink "AGENTS.md"
 ln -sf "$DOTFILES/AGENTS.md" "$HOME/.claude/CLAUDE.md"
 
 create_symlink ".default-npm-packages"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* チョア
  * セットアップ時のシンボリックリンクを見直し、$HOME/.claude/CLAUDE.md が $DOTFILES/AGENTS.md を指すように変更。
  * これに伴い、従来の $HOME/.claude/AGENTS.md のリンクは新規作成されません。
  * 既存環境では、不要になった古いリンクの削除と、新しいパス（CLAUDE.md）への参照更新が必要な場合があります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->