### PR TITLE
chore: update ghq root path

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -44,7 +44,7 @@
   smudge = git-lfs smudge -- %f
 
 [ghq]
-  root = ~/.ghq
+  root = ~/ghq
 
 [secrets]
   providers = git secrets --aws-provider


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ghq のルートディレクトリを ~/.ghq から ~/ghq に変更。
  * 新規取得・管理されるリポジトリの保存先が ~/ghq になります。既存の ~/.ghq 配下は自動移行されません。
  * 影響は ghq の保存先のみで、その他の挙動への変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->