### PR TITLE
chore: remove truncation_symbol from directory module

### DIFF
--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -49,7 +49,6 @@ crust = "#11111b"
 style = "fg:base bg:red"
 format = "[ $path ]($style)"
 truncation_length = 3
-truncation_symbol = "…/"
 truncate_to_repo = true
 
 [git_branch]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Starship設定ファイルを更新し、ディレクトリパス表示のトランケーション記号をデフォルト動作に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->