### PR TITLE
docs: mise セットアップ手順のコードブロックを分割

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 ```sh
 mise trust
+```
+
+```sh
 mise run setup
 ```
 


### PR DESCRIPTION
## リリースノート

- README の mise セットアップ手順を `mise trust` と `mise run setup` の個別コードブロックに分割