### PR TITLE
chore: Claude Code 設定にモデル指定を追加

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -110,6 +110,7 @@
   },
   "language": "japanese",
   "alwaysThinkingEnabled": true,
+  "effortLevel": "xhigh",
   "showThinkingSummaries": true,
-  "effortLevel": "xhigh"
+  "model": "claude-fable-5[1m]"
 }


### PR DESCRIPTION
## リリースノート

- Claude Code 設定に使用モデルとして claude-fable-5 の指定を追加