### PR TITLE
build: update タスクに pnpm store prune を追加

### DIFF
--- a/mise-tasks/update.toml
+++ b/mise-tasks/update.toml
@@ -20,6 +20,10 @@ run = 'fish -c "fisher update"'
 description = "Neovim プラグインを更新"
 run = 'nvim --headless "+Lazy! sync" +qa'
 
+["update:pnpm"]
+description = "pnpm ストアを整理"
+run = "pnpm store prune"
+
 [update]
 description = "すべての環境ツールを更新"
 quiet = true
@@ -37,6 +41,9 @@ run = [
   "echo ''",
   "echo '⚡ Updating Neovim plugins...'",
   "mise run update:nvim",
+  "echo ''",
+  "echo '📦 Pruning pnpm store...'",
+  "mise run update:pnpm",
   "echo ''",
   "echo '✅ All updates completed!'",
 ]


### PR DESCRIPTION
## リリースノート

- pnpm ストアの未参照パッケージを削除する update:pnpm タスクを追加
- 統合 update タスクに pnpm ストア整理ステップを組み込み