### PR TITLE
chore: 非メジャーと digest 更新の Renovate 自動マージを有効化

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,15 +12,17 @@
     {
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "{{manager}} (non-major)",
-      "groupSlug": "{{manager}}-non-major"
+      "groupSlug": "{{manager}}-non-major",
+      "automerge": true
     },
     {
       "matchUpdateTypes": ["major"],
       "minimumReleaseAge": "7 days"
     },
     {
-      "matchUpdateTypes": ["pin", "pinDigest"],
-      "minimumReleaseAge": "0 days"
+      "matchUpdateTypes": ["pin", "pinDigest", "digest"],
+      "minimumReleaseAge": "0 days",
+      "automerge": true
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## リリースノート

- minor / patch 更新の自動マージを有効化
- pin / pinDigest 更新の自動マージを有効化
- digest 更新を自動マージ対象に追加