### PR TITLE
ci: preset-pr の addAssignees に await を追加

### DIFF
--- a/.github/workflows/preset-pr.yml
+++ b/.github/workflows/preset-pr.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.rest.issues.addAssignees({
+            await github.rest.issues.addAssignees({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## リリースノート

- PR 作成時の assignee 自動設定で GitHub API 呼び出しの完了を待機するよう修正
- API 呼び出しが失敗した場合にワークフローがエラーを検知できるよう改善