### PR TITLE
ci: biome workflow のツールインストールを node と pnpm に限定

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d  # v4.2.0
+        with:
+          install_args: node pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: biome


### PR DESCRIPTION
## リリースノート

- biome の CI ジョブでインストールするツールを node と pnpm のみに限定
- 不要なツールのインストールを省略し CI 実行時間を短縮