### PR TITLE
chore: Renovate で yamllint のバージョンを追跡

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,15 @@
       "automerge": true
     }
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^mise\\.toml$/"],
+      "matchStrings": ["yamllint==(?<currentValue>[\\d.]+)"],
+      "depNameTemplate": "yamllint",
+      "datasourceTemplate": "pypi"
+    }
+  ],
   "vulnerabilityAlerts": {
     "minimumReleaseAge": "0 days",
     "labels": ["security"]


### PR DESCRIPTION
## リリースノート

- mise タスクで固定している yamllint のバージョンを Renovate の追跡対象に追加
- yamllint の更新 PR を自動作成できるよう改善