### PR TITLE
fix: fish の git 補助関数のエッジケースを修正

### DIFF
--- a/home/.config/fish/functions/_get_git_remote.fish
+++ b/home/.config/fish/functions/_get_git_remote.fish
@@ -1,6 +1,12 @@
 function _get_git_remote
 
-    set -l branch (git rev-parse --abbrev-ref HEAD)
+    set -l branch (git branch --show-current)
+
+    if test -z "$branch"
+        echo "Error: Cannot determine branch in detached HEAD state" >&2
+        return 1
+    end
+
     set -l remote (git config --get branch.$branch.remote 2>/dev/null)
 
     if test -z "$remote"

--- a/home/.config/fish/functions/ggclean.fish
+++ b/home/.config/fish/functions/ggclean.fish
@@ -5,7 +5,7 @@ function ggclean --description "Discard all git changes"
 
     set -l changes (git status --porcelain)
     if test -z "$changes"
-        echo "No changes to stash"
+        echo "No changes to discard"
         return 0
     end
 

--- a/home/.config/fish/functions/ggstash.fish
+++ b/home/.config/fish/functions/ggstash.fish
@@ -36,6 +36,7 @@ function ggstash --description "Manage git stashes"
             end
 
             read -P "Stash message: " -l stash_message
+            or return 0
 
             if test -z "$stash_message"
                 echo "Error: No stash message entered" >&2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Detached HEAD 状態ではブランチを特定できないことを明示し、処理を早期に停止するようになりました。
  * リモート解決に進む前に失敗を検出できるため、より分かりやすいエラー表示になります。
  * 変更を破棄する操作で、表示メッセージを実際の内容に合わせて修正しました。
  * スタッシュ用の入力取得に失敗した場合は、そのまま中断するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->