### PR TITLE
fix: pre-commit の fish 構文チェックの検査漏れを修正

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -27,7 +27,7 @@ pre-commit:
       run: pnpm exec taplo fmt --check {staged_files}
     fish:
       glob: "**/*.fish"
-      run: fish -n {staged_files}
+      run: for f in {staged_files}; do fish -n "$f" || exit 1; done
     fish_indent:
       glob: "**/*.fish"
       run: fish_indent --check {staged_files}


### PR DESCRIPTION
## リリースノート

- 複数の fish ファイルを同時にコミットした際に先頭以外が構文チェックされない問題を修正
- pre-commit の fish 構文チェックをファイルごとに実行するよう変更