### PR TITLE
chore: git mergetool を nvimdiff に変更

### DIFF
--- a/home/.config/git/config
+++ b/home/.config/git/config
@@ -23,7 +23,7 @@
 
 [merge]
   conflictStyle = zdiff3
-  tool = vimdiff
+  tool = nvimdiff
 
 [diff]
   algorithm = histogram


### PR DESCRIPTION
## リリースノート

- git の mergetool を vimdiff から nvimdiff に変更