### PR TITLE
chore: glow を leaf-md に置き換え

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -26,14 +26,14 @@ brew "ghq"
 brew "git"
 # Syntax-highlighting pager for git and diff output
 brew "git-delta"
-# Render markdown on the CLI
-brew "glow"
 # Command-line tool for generating regular expressions
 brew "grex"
 # Command-line benchmarking tool
 brew "hyperfine"
 # Lightweight and flexible command-line JSON processor
 brew "jq"
+# Terminal Markdown previewer with a GUI-like experience
+brew "leaf-md"
 # Mac App Store command-line interface
 brew "mas"
 # Polyglot runtime manager (asdf rust clone)


### PR DESCRIPTION
## リリースノート

- Markdown プレビューツールを glow から leaf-md へ置き換え