### PR TITLE
chore: 強制していたシェル環境変数を削除

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -2,8 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "cleanupPeriodDays": 90,
   "env": {
-    "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
-    "SHELL": "/opt/homebrew/bin/fish"
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "0"
   },
   "permissions": {
     "allow": [


### PR DESCRIPTION
## リリースノート

- 設定で強制していたシェル環境変数を削除
- シェルを実行環境からの継承に変更
