### PR TITLE
ci: ワークフローを整理し共通 setup アクションを追加

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,18 @@
+name: setup
+description: mise でツールをセットアップし、依存関係をインストールする
+
+inputs:
+  mise-install-args:
+    description: mise-action に渡すツール指定
+    required: false
+    default: node pnpm
+
+runs:
+  using: composite
+  steps:
+    - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d  # v4.2.0
+      with:
+        install_args: ${{ inputs.mise-install-args }}
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,4 +1,4 @@
-name: gitleaks
+name: security
 
 on:
   pull_request:
@@ -24,5 +24,5 @@ jobs:
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d  # v4.2.0
         with:
           install_args: gitleaks
-      - name: gitleaks
+      - name: Run gitleaks
         run: gitleaks git --log-opts "origin/main..HEAD"

--- a/.github/workflows/static-check.yml
+++ b/.github/workflows/static-check.yml
@@ -1,4 +1,4 @@
-name: biome
+name: static-check
 
 on:
   pull_request:
@@ -20,10 +20,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d  # v4.2.0
-        with:
-          install_args: node pnpm
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: biome
+      - uses: ./.github/actions/setup
+      - name: Run biome
         run: pnpm exec biome ci


### PR DESCRIPTION
## リリースノート

- 共通セットアップ用の `setup` composite action を追加
- 静的解析ワークフローを `static-check` へ集約
- gitleaks ワークフローを `security` へリネーム
- ワークフローのセットアップ手順を `setup` action へ共通化
