### PR TITLE
ci: Biome の更新をグループ化

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,11 @@
       "matchUpdateTypes": ["pin", "pinDigest", "digest"],
       "minimumReleaseAge": "0 days",
       "automerge": true
+    },
+    {
+      "matchDepNames": ["@biomejs/biome"],
+      "groupName": "biome",
+      "groupSlug": "biome"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## リリースノート

- Renovate で Biome の依存更新を単一グループへ集約する設定を追加