### PR TITLE
feat: Claude Code のステータスラインを追加

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -111,6 +111,11 @@
       }
     ]
   },
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh",
+    "padding": 0
+  },
   "language": "japanese",
   "alwaysThinkingEnabled": true,
   "effortLevel": "xhigh",

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+IFS=$'\t' read -r model cwd pct < <(
+  jq -r '[
+    (.model.display_name // "?"),
+    (.workspace.current_dir // .cwd // "."),
+    (.context_window.used_percentage // 0 | floor)
+  ] | @tsv'
+)
+
+branch=$(git -C "$cwd" branch --show-current 2>/dev/null)
+[ -z "$branch" ] && branch=$(git -C "$cwd" rev-parse --short HEAD 2>/dev/null)
+
+echo "${cwd##*/} | ${branch:--} | $model | ${pct}%"


### PR DESCRIPTION
## リリースノート

- Claude Code のステータスラインを追加
- カレントディレクトリ名とブランチ名を表示
- モデル名とコンテキストウィンドウ使用率を表示
- Git リポジトリ外や detached HEAD でも表示が崩れないようフォールバックを実装
