### PR TITLE
fix: Homebrew の cask 更新失敗を解消

### DIFF
--- a/home/.config/fish/config.fish
+++ b/home/.config/fish/config.fish
@@ -1,7 +1,7 @@
 set -gx EDITOR nvim
 set -gx FZF_DEFAULT_OPTS "--height 100% --reverse --border=rounded --no-sort --ansi --info=inline --preview-window=right:50%:wrap --bind 'ctrl-/:preview-page-down,ctrl-\:preview-page-up'"
 set -gx HOMEBREW_BUNDLE_DUMP_NO_NPM 1
-set -gx HOMEBREW_NO_ENV_HINTS 1
+set -gx HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS 1
 set -gx LANG ja_JP.UTF-8
 set -gx RIPGREP_CONFIG_PATH $HOME/.ripgreprc
 set -gx XDG_CONFIG_HOME $HOME/.config


### PR DESCRIPTION
## リリースノート

- 自動更新される cask を `brew upgrade` の対象外にする `HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS` を追加
- Homebrew のヒント出力を抑止する `HOMEBREW_NO_ENV_HINTS` を削除
