### PR TITLE
feat: エディタを VS Code から Zed へ移行

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -101,8 +101,8 @@ cask "raycast"
 cask "slack"
 # Native GUI tool for relational databases
 cask "tableplus"
-# Open-source code editor
-cask "visual-studio-code"
+# Multiplayer code editor
+cask "zed"
 # Video communication and virtual meeting platform
 cask "zoom"
 mas "EdgeView", id: 1580323719
@@ -111,14 +111,3 @@ mas "LINE", id: 539883307
 mas "Messenger", id: 1480068668
 mas "Things", id: 904280696
 mas "Xcode", id: 497799835
-vscode "alefragnani.bookmarks"
-vscode "alefragnani.project-manager"
-vscode "catppuccin.catppuccin-vsc"
-vscode "catppuccin.catppuccin-vsc-icons"
-vscode "eamodio.gitlens"
-vscode "editorconfig.editorconfig"
-vscode "mechatroner.rainbow-csv"
-vscode "ms-ceintl.vscode-language-pack-ja"
-vscode "streetsidesoftware.code-spell-checker"
-vscode "usernamehw.errorlens"
-vscode "vscodevim.vim"

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -7,7 +7,11 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["**", "!home/.config/karabiner/karabiner.json"]
+    "includes": [
+      "**",
+      "!home/.config/karabiner/karabiner.json",
+      "!home/.config/zed"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/home/.config/zed/keymap.json
+++ b/home/.config/zed/keymap.json
@@ -1,0 +1,21 @@
+// Zed keymap
+//
+// For information on binding keys, see the Zed
+// documentation: https://zed.dev/docs/key-bindings
+//
+// To see the default key bindings run `zed: open default keymap`
+// from the command palette.
+[
+  {
+    "context": "Workspace",
+    "bindings": {
+      // "shift shift": "file_finder::Toggle"
+    },
+  },
+  {
+    "context": "Editor && vim_mode == insert",
+    "bindings": {
+      // "j k": "vim::NormalBefore"
+    },
+  },
+]

--- a/home/.config/zed/settings.json
+++ b/home/.config/zed/settings.json
@@ -1,0 +1,77 @@
+// Zed settings
+//
+// For information on how to configure Zed, see the Zed
+// documentation: https://zed.dev/docs/configuring-zed
+//
+// To see all of Zed's default settings without changing your
+// custom settings, run `zed: open default settings` from the
+// command palette (cmd-shift-p / ctrl-shift-p)
+{
+  "telemetry": {
+    "diagnostics": false,
+    "metrics": false,
+    "anthropic_retention": false
+  },
+  "session": {
+    "trust_all_worktrees": true
+  },
+  "vim_mode": true,
+  "terminal": {
+    "font_size": 14.0,
+    "font_family": "JetBrainsMono Nerd Font Mono",
+    "font_fallbacks": [
+      "BIZ UDGothic"
+    ],
+    "line_height": {
+      "custom": 1.2
+    },
+    "max_scroll_history_lines": 10000
+  },
+  "project_panel": {
+    "auto_fold_dirs": false
+  },
+  "base_keymap": "VSCode",
+  "preview_tabs": {
+    "enabled": false
+  },
+  "sticky_scroll": {
+    "enabled": true
+  },
+  "minimap": {
+    "show": "never"
+  },
+  "cursor_blink": true,
+  "autosave": {
+    "after_delay": {
+      "milliseconds": 1000
+    }
+  },
+  "buffer_font_fallbacks": [
+    "BIZ UDGothic"
+  ],
+  "buffer_font_family": "JetBrainsMono Nerd Font Mono",
+  "linked_edits": true,
+  "show_whitespaces": "boundary",
+  "ensure_final_newline_on_save": true,
+  "soft_wrap": "editor_width",
+  "agent_servers": {
+    "codex-acp": {
+      "type": "registry"
+    },
+    "claude-acp": {
+      "type": "registry"
+    }
+  },
+  "icon_theme": {
+    "mode": "dark",
+    "light": "Catppuccin Mocha",
+    "dark": "Catppuccin Mocha"
+  },
+  "ui_font_size": 16,
+  "buffer_font_size": 14.0,
+  "theme": {
+    "mode": "dark",
+    "light": "Catppuccin Latte",
+    "dark": "Catppuccin Mocha",
+  },
+}


### PR DESCRIPTION
## リリースノート

- エディタを VS Code から Zed へ移行
- VS Code 本体と拡張機能の定義を削除
- Zed の設定と keymap を追加
- Vim モードや Catppuccin テーマ、自動保存など Zed の初期設定を有効化
- biome のチェック対象から Zed の設定を除外