### PR TITLE
feat: ggls コマンドを追加

### DIFF
--- a/home/.config/fish/functions/ggls.fish
+++ b/home/.config/fish/functions/ggls.fish
@@ -1,0 +1,20 @@
+function ggls --description "Select tracked files and set absolute paths to prompt"
+
+    _assert_in_git_repository
+    or return 1
+
+    set -l root (git rev-parse --show-toplevel)
+
+    set -l files (git -C $root ls-files | \
+        fzf --multi --prompt="Select files: ")
+
+    if test -n "$files"
+        set -l escaped_files
+        for file in $files
+            set -a escaped_files (string escape -- "$root/$file")
+        end
+        _set_commandline "$escaped_files"
+        commandline -C 0
+        commandline -f repaint
+    end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Gitリポジトリ内の追跡ファイルを、`fzf`で複数選択できるシェル機能を追加しました。
  - 選択したファイルの絶対パスを、エスケープ済みの状態でコマンドラインに入力できます。
  - 実行後はコマンドラインをリセットし、画面を自動的に再描画します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->