### PR TITLE
refactor: ステータスラインをモデルと使用率のみの表示に簡素化

### DIFF
--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -1,14 +1,10 @@
 #!/bin/bash
 
-IFS=$'\t' read -r model cwd pct < <(
+IFS=$'\t' read -r model pct < <(
   jq -r '[
     (.model.display_name // "?"),
-    (.workspace.current_dir // .cwd // "."),
     (.context_window.used_percentage // 0 | floor)
   ] | @tsv'
 )
 
-branch=$(git -C "$cwd" branch --show-current 2>/dev/null)
-[ -z "$branch" ] && branch=$(git -C "$cwd" rev-parse --short HEAD 2>/dev/null)
-
-echo "${cwd##*/} | ${branch:--} | $model | ${pct}%"
+echo "$model | ${pct}%"


### PR DESCRIPTION
## リリースノート

- ステータスラインからリポジトリ名の表示を削除
- ステータスラインからブランチ名の表示を削除
- ブランチ取得のための git 呼び出し処理を削除
- 表示項目をモデル名と使用率のみに簡素化