### PR TITLE
chore: Zed のエディタ設定を更新

### DIFF
--- a/home/.config/zed/settings.json
+++ b/home/.config/zed/settings.json
@@ -50,6 +50,9 @@
     "BIZ UDGothic"
   ],
   "buffer_font_family": "JetBrainsMono Nerd Font Mono",
+  "buffer_font_features": {
+    "calt": false
+  },
   "linked_edits": true,
   "show_whitespaces": "boundary",
   "ensure_final_newline_on_save": true,
@@ -73,5 +76,11 @@
     "mode": "dark",
     "light": "Catppuccin Latte",
     "dark": "Catppuccin Mocha",
+  },
+  "auto_install_extensions": {
+    "catppuccin": true,
+    "catppuccin-icons": true,
+    "html": true,
+    "toml": true,
   },
 }


### PR DESCRIPTION
## リリースノート

- `buffer_font_features` に `calt: false` を追加しリガチャ(合字)を無効化
- `auto_install_extensions` を追加し catppuccin / catppuccin-icons / html / toml 拡張を自動インストール
