### PR TITLE
chore: herdr の設定を更新

### DIFF
--- a/home/.config/herdr/config.toml
+++ b/home/.config/herdr/config.toml
@@ -1,5 +1,10 @@
+onboarding = false
+
 [theme]
 name = "catppuccin"
 
 [ui.toast]
 delivery = "system"
+
+[terminal]
+new_cwd = "current"


### PR DESCRIPTION
## リリースノート

- herdr のオンボーディング表示を無効化
- 新規ターミナルの作業ディレクトリを現在のディレクトリに変更
