### PR TITLE
chore: Renovate を週次実行に変更

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
     "customManagers:biomeVersions"
   ],
   "timezone": "Asia/Tokyo",
-  "schedule": ["* 12-17 * * *"],
+  "schedule": ["* 6-11 * * 6"],
+  "prHourlyLimit": 0,
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {


### PR DESCRIPTION
## リリースノート

- Renovate の実行スケジュールを毎日 12:00-17:59 から土曜 06:00-11:59 に変更
- 時間あたりの PR 作成上限を撤廃
