### PR TITLE
fix: Ghostty の Ctrl+[ キーバインド設定を削除

### DIFF
--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -27,7 +27,6 @@ cursor-style-blink = false
 # Input
 mouse-hide-while-typing = true
 keybind = super+enter=toggle_fullscreen
-keybind = ctrl+[=text:\x1b
 
 # Clipboard
 copy-on-select = clipboard


### PR DESCRIPTION
## リリースノート

- Ghostty の Ctrl+[ キーバインド設定を削除
